### PR TITLE
[고경표]w4_리뷰요청_일래스틱 서치 연결

### DIFF
--- a/client/search/app-bar.js
+++ b/client/search/app-bar.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import GoBackIcon from '@material-ui/icons/ArrowBackRounded';
+import AppBar from '@material-ui/core/AppBar';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  header: {
+    height: '2.4rem',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: '0.1rem',
+  },
+  titleBackground: {
+    width: '100vw',
+    display: 'flex',
+    justifyContent: 'center',
+    '& h2': {
+      fontWeight: 'bold',
+      fontSize: '0.9rem'
+    }
+  }
+});
+
+const Header = ({ title }) => {
+  const classes = useStyles({});
+  return (
+    <AppBar position='static' className={classes.header} color='white'>
+      <GoBackIcon />
+      <div className={classes.titleBackground}>
+        <h2>{title}</h2>
+      </div>
+    </AppBar>
+  );
+};
+
+Header.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default Header;

--- a/client/search/es-result-converter.js
+++ b/client/search/es-result-converter.js
@@ -1,0 +1,12 @@
+/**
+ * 본 메소드는 서버로부터 받은 데이터를 클라이언트 환경에 맞게 변환하는 메소드입니다.
+ * 서버에서 데이터를 받은 후 서버에서 가공하는 방법도 있지만 이 방법보다 서버에서 처리하는 시간을
+ * 줄이고(공개해서는 안되는 정보를 필터링을 거치고)
+ * 클라이언트(프론트)에서 처리하는 것이 여러 요청이 왔을 때 처리하는 것이 좋다고 생각되어
+ * 여기서 변환하도록 하였습니다.
+ * 
+ * 지금은 단순히 연동이 되는지 확인하기 위해 임시로 만들어두었습니다.
+ */
+const convertESResultToSimpleList = (data) => ({ title: data._source.title, id: data._id });
+
+export default convertESResultToSimpleList;

--- a/client/search/index.js
+++ b/client/search/index.js
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react';
+import Header from './app-bar';
+import SimpleList from '../../components/simple-list';
+import Search from '../../components/simple-search';
+import request from '../../utils/request';
+import useContainerStyle from './style';
+import convertESResultToSimpleList from './es-result-converter';
+
+/**
+ * 서버로부터 특정 키워드를 입력받아 state를 변경하는 함수입니다.
+ * useEffect내에서 처리하려고 하였으나 eslint dependency 경고메시지로 
+ * 별도의 함수로 빼두었고, setState는 콜백함수를 전달하여 처리하도록 하였습니다.
+ * @param {*} keyword 검색어
+ * @param {*} from elastic search의 from (시작 점)
+ * @param {*} size elastic search의 size (가져올 데이터의 수)
+ * @param {*} setList callback 함수, useState의 setState
+ * @param {*} list useState의 state
+ */
+const getDataFromServer = async (keyword, from, size, setList, list = []) => {
+  const response = await request(keyword, from, size);
+  const listConverted = response.data.map(convertESResultToSimpleList);
+  if (from > 0 && listConverted.length > 0) {
+    setList([...list, ...listConverted])
+  } else {
+    setList(listConverted);
+  }
+};
+
+/**
+ * 스크롤이 하단으로 이동했을 때, 해당 콜백을 실행하는 메소드 입니다.
+ * @param {}} cb 
+ */
+const scrollBottomDetectionEvent = (cb) => {
+  const bottom = (window.innerHeight + window.scrollY >= document.body.offsetHeight);
+  if (bottom) {
+    cb();
+  }
+};
+
+export default () => {
+  const [list, setList] = useState([]); // 검새결과를 담을 state
+  const [from, setFrom] = useState(0);  // 페이지네이션을 위한 state
+  const [keyword, setKeyword] = useState(null); // 검색결과를 담을 state
+  const [loading, setLoading] = useState(false); // 검색결과를 받아오는동안 재요청을 방지하기 위한 state
+  const pageSize = 10;  // 한 페이지에 보여질 리스트의 수
+  const classes = useContainerStyle({ bgColor: '#d8d8d8' });
+
+  const getListByKeyword = (event, inputRef) => {
+    event.preventDefault();
+    const inputValue = inputRef.current.value;
+    setKeyword(inputValue);
+    setFrom(0);
+  };
+
+  const updatePage = () => {
+    setLoading(true);
+    getDataFromServer(keyword, from, pageSize, setList, list)
+    setLoading(false);
+  }
+
+  const addTurnPageEvent = () => {
+    const nextPage = () => {
+      if (loading) {
+        return;
+      }
+      setFrom((page) => page + 1);
+    };
+    const event = scrollBottomDetectionEvent.bind(this, nextPage);
+    window.addEventListener('wheel', event);
+    window.addEventListener('touchmove', event);
+  }
+
+  useEffect(updatePage, [from, keyword]);
+  useEffect(addTurnPageEvent, []);
+
+  return (
+    <>
+      <Header title='제품명 검색' />
+      <div className={classes.search}>
+        <Search bgColor='white' submitEvent={getListByKeyword} onChangeEvent={getListByKeyword} />
+      </div>
+      <div className={classes.contents}>
+        <SimpleList contents={list} />
+      </div>
+    </>
+  );
+};

--- a/client/search/style.js
+++ b/client/search/style.js
@@ -1,0 +1,17 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useContainerStyle = makeStyles({
+  search: props => ({
+    backgroundColor: props.bgColor,
+    padding: '1rem',
+    height: '3rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }),
+  contents: {
+    padding: '0 1rem',
+  }
+});
+
+export default useContainerStyle;

--- a/client/utils/request.js
+++ b/client/utils/request.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+/**
+ * 서버로부터 요청을 전달받기 위한 단순한 함수입니다.
+ * 별다른 예외처리는 하지 않았습니다.
+ * @param {*} keyword 
+ * @param {*} from 
+ * @param {*} size 
+ */
+const request = async (keyword, from, size) => {
+  const uri = 'http://localhost:5000/products'; // test
+  const skip = from * size;
+  const requestUri = `${uri}?keyword=${keyword}&from=${skip}&limits=${size}`;
+  try {
+    const response = await axios.get(requestUri);
+    return response;
+  } catch (e) {
+    return {};
+  }
+};
+
+export default request;

--- a/server/core/index.js
+++ b/server/core/index.js
@@ -1,0 +1,143 @@
+import model from '../db/model';
+import message from './message';
+
+const Product = model.product;
+
+const Core = {
+  lastModifed: Date.now(),
+  getLastModified() {
+    return Core.lastModifed;
+  },
+  refreshLastModified() {
+    Core.lastModifed = Date.now();
+  },
+  /**
+ * 중고 상품 등록
+ * @param {*} contents 새로운 데이터(Product 스키마를 따름)
+ * @returns {Promise<String>} Object(등록 완료)
+ */
+  async insertProduct(contents) {
+    Core.refreshLastModified();
+    try {
+      const result = await Product.create(contents);
+      return result;
+    } catch (e) {
+      throw Error(message.errorProcessing);
+    }
+  },
+
+  /**
+   * 등록된 중고상품 조회
+   * @description 검색 조건에 일치하는 정보를 찾아 리스트로 반환합니다.
+   * @param {Number} page 페이지네이션 번호 (default 1)
+   * @param {Number} limits 총 출력할 갯수 (default 10)
+   * @param {Object} options where 조건(필터) (default {})
+   * @param {Object} sort 정렬 방법 (default { order:-1, createdAt: -1})
+   * @returns {Promise<(Object|Array)>} Array(조회 결과)
+   */
+  async getProducts(page = 1, limits = 10,
+    options = {}, sort = { order: -1, createdAt: -1 }) {
+    try {
+      const result = await Product
+        .find(options || {})
+        .sort(sort)
+        .skip((page - 1) * limits)
+        .limit(limits);
+      return result;
+    } catch (e) {
+      throw Error(message.errorProcessing);
+    }
+  },
+
+  /**
+   * 등록된 중고상품 정보 수정
+   * @description 유저 아이디와 실제 document를 등록한 사용자가 일치할 경우에만 해당 정보를 수정합니다.
+   * 상태값이 '비공개'일 경우 일래스틱 서치에서 인덱스 목록에 제거합니다.
+   * @param {String} _id 기본키(Object_ID)
+   * @param {String} userId 유저정보(사용자)
+   * @param {Object} contents 업데이트할 내용(product 모델 참조)
+   * @return {Promise<Object>} Object(Product object)
+   */
+  async updateProduct(_id, userId, contents) {
+    const isCurrentStatusPrivate = (document) => document.currentStatus === '비공개';
+    Core.refreshLastModified();
+    try {
+      const product = await Product.findById(_id);
+      if (product.userId !== userId) {
+        throw Error(message.doNotHavePermission);
+      }
+      Object.keys(contents).forEach((key) => {
+        product[key] = contents[key];
+      });
+      if (isCurrentStatusPrivate(product)) {
+        await product.unIndex();
+      }
+      const result = await product.save();
+      return result;
+    } catch (e) {
+      throw Error(message.errorProcessing);
+    }
+  },
+
+  /**
+   * 등록된 중고상품 삭제
+   * @description 유저 아이디와 실제 document를 등록한 사용자가 일치할 경우에만 해당 정보를 삭제합니다..
+   * @param {String} _id 기본키(Object_ID)
+   * @param {String} userId 유저정보(사용자)
+   * @return {Promise<Number>} 삭제 성공시 1, 실패 시 0
+   */
+  async removeProduct(_id, userId) {
+    Core.refreshLastModified();
+    try {
+      const product = await Product.findById({ _id });
+      if (product.userId !== userId) {
+        return 0;
+      }
+      await product.remove();
+      return 1;
+    } catch (e) {
+      return 0;
+    }
+  },
+
+  /**
+   * 일래스틱 서치 검색
+   * @description 일래스틱 서치 검색결과를 조회합니다.
+   * @param {Object.<from, size, filter, query, sort>} esquery 일래스틱 서치 쿼리
+   * @param esquery.from 시작 지점(페이지 네이션)
+   * @param esquery.size 한번에 보여줄 페이지의 수
+   * @param esquery.query 일래스틱 서치 쿼리
+   * @param esquery.sort 일래스틱 서치 정렬
+   */
+  async getElasticSearchResults(esquery) {
+    let sort = esquery.sort || [];
+    const isNotDefaultSetSortOption = (arr) => !arr || !arr.includes((info) => 'order' in info);
+    if (isNotDefaultSetSortOption(sort)) {
+      sort = [
+        ...sort,
+        { order: 'desc' },
+      ];
+    }
+    const query = { ...esquery, sort };
+    try {
+      const respone = await Product.search(query, {});
+      const result = respone.hits.hits;
+      return result;
+    } catch (e) {
+      throw new Error(e);
+    }
+  },
+  getProductSchemaByKey(key) {
+    return Product.schema.path(key);
+  },
+};
+
+export const {
+  insertProduct,
+  updateProduct,
+  removeProduct,
+  getProducts,
+  getProductSchemaByKey,
+  getElasticSearchResults,
+  getLastModified,
+} = Core;

--- a/server/core/message.js
+++ b/server/core/message.js
@@ -1,0 +1,8 @@
+export default {
+  invalidCategory: '유효하지 않은 카테고리 입니다.',
+  invalidPriceRange: '올바르지 않은 가격범위입니다.',
+  invalidStatus: '유효하지 않은 거래상태입니다.',
+  errorProcessing: '처리중 오류가 발생하였습니다',
+  enterAllRequiredFields: '필수 항목을 모두 올바르게 입력하세요',
+  doNotHavePermission: '권한이 없습니다.',
+};

--- a/server/core/string-conveter.js
+++ b/server/core/string-conveter.js
@@ -1,0 +1,75 @@
+/**
+ * host/path?query에서
+ * query를 elastic search에 맞는 query로 변경하기 위한 메소드 모음입니다.
+ */
+import message from './message';
+import { getProductSchemaByKey } from './index';
+
+const convertStringStatusToQuery = (status) => {
+  const secretField = '비공개';
+  const currentStatus = getProductSchemaByKey('currentStatus').enumValues.filter((name) => name !== secretField);
+  const isCorrectStatusName = (name) => currentStatus.includes(name);
+  const statusList = status.split(',');
+  const statusTestResult = statusList.every(isCorrectStatusName);
+  if (!statusTestResult) {
+    throw new Error(message.invalidStatus);
+  }
+  const query = statusList.reduce((cur, name) => [...cur, { match: { currentStatus: name } }], []);
+  return { should: query };
+};
+
+const convertStringPriceRangeToQuery = (price) => {
+  const [min, max] = price.split(',');
+  if (+min > 0 && !max) {
+    return {
+      range: {
+        price: { gte: +min },
+      },
+    };
+  }
+  if (+min < 0 || +min > +max) {
+    throw new Error(message.invalidPriceRange);
+  }
+  return {
+    range: {
+      price: {
+        gte: +min,
+        lte: +max,
+      },
+    },
+  };
+};
+
+const convertStringCategoryToQuery = (categories) => {
+  const categoryRange = getProductSchemaByKey('category').enumValues;
+  const category = categories.split(',');
+  const isCorrectCategoryName = (name) => categoryRange.includes(name);
+  const properInput = category.every(isCorrectCategoryName);
+  if (!properInput) {
+    throw new Error(message.invalidCategory);
+  }
+  const query = category.reduce((cur, name) => [...cur, { match: { category: name } }], []);
+  return { should: query };
+};
+
+const convertOrderTypeFromString = (option, order) => {
+  const type = (order[0] === '-') ? 'asc' : 'desc';
+  const name = (type === 'desc') ? order : order.slice(1);
+  return [
+    ...option,
+    { [name]: type },
+  ];
+};
+
+const convertStringOrderToOption = (order) => {
+  const orders = order.split(',');
+  const options = orders.reduce(convertOrderTypeFromString, []);
+  return options;
+};
+
+export {
+  convertStringStatusToQuery,
+  convertStringPriceRangeToQuery,
+  convertStringCategoryToQuery,
+  convertStringOrderToOption,
+};

--- a/server/server-etag-generator.js
+++ b/server/server-etag-generator.js
@@ -1,0 +1,23 @@
+import etag from 'etag';
+import { getLastModified } from '../../core';
+
+const convertStringFromRequest = (req) => {
+  const params = JSON.stringify(req.params);
+  const query = JSON.stringify(req.query);
+  const body = JSON.stringify(req.body);
+  const lastModified = getLastModified().toString();
+  return params + query + body + lastModified;
+};
+
+const etagGenerator = (req, res, next) => {
+  const stringRequest = convertStringFromRequest(req);
+  const etagHeader = etag(stringRequest);
+  res.setHeader('ETag', etagHeader);
+  if (req.header('If-None-Match') === etagHeader) {
+    res.json([]);
+  } else {
+    next();
+  }
+};
+
+export default etagGenerator;


### PR DESCRIPTION
[기능 구현]

 - 사용자로부터 query 요청을 받으면 해당 query를 일래스틱 서치 query에 맞게 변환 작업을 하고
 - 검색 결과를 client에 출력하는 기능입니다.
 - 모듈은 mongosastic 을 사용하였습니다.

 - 여기에서 질문할 내용이 떠오르지 않아서 기능에 관련된 내용중 일부만 묶어서 PR을 날리고
 - 기능을 구현하면서 들었던 생각들을 질문으로 남깁니다.

[질문 1]
 - 현재 저희가 구현한(혹은 구현할) 기능의 구조는 다음과 같습니다.

    [클라이언트 1번] <--HTTP--> [CRUD API(몽고DB) 2번] <--HTTP API--> [일래트릭 서치 3번]

 - 클라이언트가 어떠한 데이터를 요청할때마다 항상 일래트릭 서치를 거치게 되는데 이 과정을 최소화하기 위해서 웹 캐싱을 활용하고자 합니다.
 
 - 생각나는 가장 간단한 방법이 eTag 헤더를 이용한 방법인데,
 - 클라이언트의 요청이 서버에서 생성한 eTag와 일치한다면 데이터베이스에 접근하지 않고 빈 데이터를 전달해서 1번 --- 2번 만 통신이 일어나고 2번 --- 3번은 통신이 일어나는 것을 줄였습니다.

 - 여기서 eTag생성하는 방법이 제가 생각난 방법으로는 요청정보와 데이터베이스 최근 수정 시각(메모리에서 유지)을 취합하여 eTag를 생성하는 방법을 이용하였는데 이 방법을 생각했을 때 아직 어떠한 단점이 있을지 생각이 나질 않아 여쭤봅니다.

[질문 2]
  - 위 도식에서 2번 서버에서 3번서버로 요청을 보낼 때 간혹가다 서버 문제 등으로 인해서 요청이 누락되는 경우가 있습니다. 이 경우 2번 (몽고 DB)와 3번의 인덱스 정보가 일치하지 않는 경우가 있는데 주로 이와 비슷한 상황에서 어떻게 처리하시는지 알고 싶습니다. 
이외에 서버간 통신이 필요한 경우가 있어서  저희가 생각한 방법으로는...
   1. 별도의 중계서버를 두어서 중계서버에서 요청큐를 가지고, 요청 받은 내용을 각각의 서버로 정상 응답을 받을때 까지 재요청(응답을 받지 못하는 경우 다시 큐에 넣어서..)
   2. 정상 응답을 받을때 까지 요청을 보낸 서버에서 재요청(푸시)
   3. 응답을 받아야 할 서버에서 다른 서버에 받을 요청이 있는지 주기적으로 확인(풀링 ?)