### PR TITLE
[이석재]w4_리뷰요청_채팅 기능 구현

### DIFF
--- a/web-apps/client/src/components/Chat.js
+++ b/web-apps/client/src/components/Chat.js
@@ -1,0 +1,255 @@
+import React, {useState, useEffect, useRef, useCallback} from 'react';
+import List from '@material-ui/core/List';
+import {makeStyles} from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import useIntersect from '../hooks/useIntersect';
+// components
+import ChatInputField from './ChatInputField';
+import ChatList from './ChatList';
+
+const useStyles = makeStyles((theme) => ({
+  bottomFix: {
+    position: 'absolute',
+  },
+  root: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper,
+    position: 'relative',
+    paddingBottom: '10rem',
+  },
+  listSection: {
+    backgroundColor: 'inherit',
+  },
+  ul: {
+    backgroundColor: 'inherit',
+    padding: 0,
+  },
+  liHeader: {
+    textAlign: 'center',
+  },
+  goToBottomBTN: {
+    position: 'fixed',
+    bottom: '3rem',
+    right: '1rem',
+  },
+}));
+
+const getConversations = (startTime = new Date()) => {
+  const startDate = new Date(startTime);
+  function getRandomInt(min, max) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+  return new Array(30)
+    .fill(0)
+    .map((_, i) => i)
+    .reduce((acc, cur, idx) => {
+      const baseDate = new Date(startDate.setDate(startDate.getDate() - idx));
+      return [
+        ...acc,
+        {
+          id: getRandomInt(0, 2),
+          message:
+            'Proactively implement interoperable products through cross-media schemas. Completely network goal-oriented benefits without unique ideas. ',
+          timestamp: baseDate.setHours(baseDate.getHours() - 1),
+        },
+        {
+          id: getRandomInt(0, 2),
+          message:
+            'Dramatically innovate impactful supply chains without adaptive innovation. Proactively impact ',
+          timestamp: baseDate.setHours(baseDate.getHours() - 2),
+        },
+        {
+          id: getRandomInt(0, 2),
+          message: 'this is left',
+          timestamp: baseDate.setHours(baseDate.getHours() - 3),
+        },
+      ];
+    }, []);
+};
+
+const formatChat = (rowChat = []) => {
+  const result = [];
+  rowChat.forEach((chat) => {
+    const chatTime = new Date(chat.timestamp);
+    const lastChat = result[result.length - 1];
+    if (
+      result.length < 1 ||
+      new Date(lastChat.baseDate).toDateString() !== chatTime.toDateString()
+    ) {
+      result.push({
+        baseDate: chatTime.setHours(0, 0, 0, 0),
+        messages: [chat],
+      });
+    } else {
+      lastChat.messages.push(chat);
+    }
+  });
+  return result;
+};
+
+export default function Chat() {
+  const classes = useStyles();
+  const [formattedChat, setFormattedChat] = useState([]);
+  const [reloadRef, entry] = useIntersect({threshold: 1});
+  const [isLoading, setIsLoading] = useState(false);
+  const [scrollHeight, setScrollHeight] = useState(null);
+
+  const chatInputRef = useRef(null);
+  const bottomEl = useRef(null);
+  const outerBoxRef = useRef(null);
+
+  const updateChat = useCallback(
+    (formattedResult) => {
+      setFormattedChat([...formattedResult, ...formattedChat]);
+    },
+    [formattedChat],
+  );
+  const genNewChat = useCallback(() => formattedChat[0], [formattedChat]);
+
+  useEffect(() => {
+    if (bottomEl.current) {
+      bottomEl.current.scrollIntoView({behavior: 'auto'});
+    }
+  }, []);
+
+  useEffect(() => {
+    const mockFetch = () =>
+      new Promise((res) => {
+        setTimeout(() => {
+          if (genNewChat()) {
+            res(getConversations(genNewChat().baseDate));
+          } else {
+            res(getConversations());
+          }
+        }, 500);
+      });
+
+    let ignore = false;
+
+    const fetchAndUpdateData = async () => {
+      let result;
+      try {
+        result = await mockFetch();
+      } catch (error) {
+        console.log(error);
+      }
+      if (!ignore) {
+        console.log('t', new Date().toISOString());
+        const formattedResult = formatChat(result.reverse());
+        updateChat(formattedResult);
+        setIsLoading(false);
+        setScrollHeight(outerBoxRef.current.scrollHeight);
+      }
+    };
+
+    if (entry.isIntersecting) {
+      setIsLoading(true);
+      fetchAndUpdateData();
+    }
+    return () => {
+      ignore = true;
+    };
+  }, [entry.isIntersecting, updateChat, genNewChat]);
+
+  useEffect(() => {
+    const currentHeight = outerBoxRef.current.scrollHeight;
+    console.log(currentHeight, scrollHeight);
+    if (scrollHeight === null) {
+      setScrollHeight(currentHeight);
+    } else if (currentHeight > scrollHeight) {
+      window.scrollTo(0, currentHeight - scrollHeight);
+    }
+  }, [formattedChat, scrollHeight]);
+
+  const goToTop = () => {
+    if (bottomEl.current) {
+      window.scrollTo({
+        behavior: 'smooth',
+        top: 0,
+      });
+    }
+  };
+  const goToBottom = () => {
+    if (bottomEl.current) {
+      window.scrollTo({
+        behavior: 'smooth',
+        top: bottomEl.current.offsetTop,
+      });
+    }
+  };
+  const insertNewMessage = (message, timestamp = new Date()) => {
+    const lastChat = formattedChat[formattedChat.length - 1];
+
+    if (
+      formattedChat.length < 1 ||
+      new Date(lastChat.baseDate).toDateString() !== timestamp.toDateString()
+    ) {
+      setFormattedChat([
+        ...formattedChat,
+        {
+          baseDate: timestamp.setHours(0, 0, 0, 0),
+          messages: [message],
+        },
+      ]);
+    } else {
+      setFormattedChat(
+        formattedChat.map((chats) => {
+          if (chats === lastChat) {
+            return {
+              ...chats,
+              messages: [
+                ...chats.messages,
+                {
+                  id: 1,
+                  message,
+                  timestamp,
+                },
+              ],
+            };
+          }
+          return chats;
+        }),
+      );
+    }
+    goToBottom();
+  };
+  const onMessageSubmit = (e) => {
+    e.preventDefault();
+    insertNewMessage(chatInputRef.current.value);
+    chatInputRef.current.value = '';
+  };
+
+  return (
+    <>
+      <List className={classes.root} subheader={<li />} ref={outerBoxRef}>
+        {isLoading && <CircularProgress />}
+        <span ref={reloadRef} />
+
+        <ChatList messagesByDate={formattedChat} />
+
+        <IconButton
+          type='submit'
+          className={classes.goToBottomBTN}
+          onClick={goToBottom}
+          aria-label='search'
+          ref={bottomEl}
+        >
+          <ArrowDownwardIcon />
+        </IconButton>
+        {/* 
+        <button type='button' ref={bottomEl} onClick={goToTop}>
+          go to top
+        </button> */}
+        <span ref={bottomEl} />
+      </List>
+      <ChatInputField
+        onMessageSubmit={onMessageSubmit}
+        chatInputRef={chatInputRef}
+      />
+    </>
+  );
+}

--- a/web-apps/client/src/components/ChatBox.js
+++ b/web-apps/client/src/components/ChatBox.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import Avatar from '@material-ui/core/Avatar';
+import Typography from '@material-ui/core/Typography';
+
+import {makeStyles} from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+    overflow: 'hidden',
+    padding: theme.spacing(0, 3),
+  },
+  paper: {
+    maxWidth: 400,
+    margin: `${theme.spacing(1)}px`,
+    padding: theme.spacing(1),
+    fontWeight: 'bold',
+  },
+  colorPaper: {
+    backgroundColor: 'grey',
+    color: 'white',
+  },
+}));
+
+export default function ChatBox({message, isMyChat, timestamp}) {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Grid container alignItems='center'>
+        {!isMyChat && (
+          <Grid item>
+            <Avatar>W</Avatar>
+          </Grid>
+        )}
+        <Grid item>
+          <Grid
+            container
+            direction={!isMyChat ? 'row' : 'row-reverse'}
+            alignItems='flex-end'
+          >
+            <Grid item>
+              <Paper
+                className={`${classes.paper} ${!isMyChat &&
+                  classes.colorPaper}`}
+              >
+                <Typography>{message}</Typography>
+              </Paper>
+            </Grid>
+            <Grid item>
+              <Typography variant='caption'>
+                {new Date(timestamp).toLocaleDateString('ko-KR', {
+                  weekday: 'long'
+                })}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}

--- a/web-apps/client/src/components/ChatInputField.js
+++ b/web-apps/client/src/components/ChatInputField.js
@@ -1,0 +1,59 @@
+import React, {useEffect, useState} from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import InputBase from '@material-ui/core/InputBase';
+import IconButton from '@material-ui/core/IconButton';
+import SendIcon from '@material-ui/icons/Send';
+
+import socketIOClient from 'socket.io-client';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: '2px 4px',
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    position: 'fixed',
+    bottom: '0',
+    right: '0',
+    zIndex: 100,
+    backgroundColor: 'lightgreen',
+  },
+  input: {
+    marginLeft: theme.spacing(1),
+    flex: 1,
+  },
+  iconButton: {
+    padding: 10,
+    color: 'white',
+  },
+}));
+
+const ChatInputField = ({onMessageSubmit, chatInputRef}) => {
+  const classes = useStyles();
+  const send = () => {
+    const socket = socketIOClient('localhost:5000');
+    socket.emit('this is', 'test');
+  };
+
+  return (
+    <Paper component='form' className={classes.root}>
+      <InputBase
+        className={classes.input}
+        placeholder='메세지를 입력하세요.'
+        inputProps={{'aria-label': 'search google maps'}}
+        inputRef={chatInputRef}
+      />
+      <IconButton
+        type='submit'
+        className={classes.iconButton}
+        onClick={onMessageSubmit}
+        aria-label='search'
+      >
+        <SendIcon />
+      </IconButton>
+    </Paper>
+  );
+};
+
+export default ChatInputField;

--- a/web-apps/client/src/components/ChatList.js
+++ b/web-apps/client/src/components/ChatList.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import ListItem from '@material-ui/core/ListItem';
+import ListSubheader from '@material-ui/core/ListSubheader';
+import {makeStyles} from '@material-ui/core/styles';
+
+import ChatRow from './ChatRow';
+
+const useStyles = makeStyles((theme) => ({
+  bottomFix: {
+    position: 'absolute',
+  },
+  root: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper,
+    position: 'relative',
+    overflow: 'auto',
+    maxHeight: '100vh',
+    paddingBottom: '5rem',
+  },
+  listSection: {
+    backgroundColor: 'inherit',
+  },
+  ul: {
+    backgroundColor: 'inherit',
+    padding: 0,
+  },
+  liHeader: {
+    textAlign: 'center',
+  },
+}));
+
+export default function ChatList({messagesByDate = []}) {
+  const classes = useStyles();
+
+
+  return messagesByDate.map((msgs, idx) => {
+    const {baseDate, messages} = msgs;
+    return (
+      <li key={`section-${baseDate}`} className={classes.listSection}>
+        <ul className={classes.ul}>
+          <ListSubheader className={classes.liHeader}>
+            {new Date(baseDate).toLocaleDateString('ko-KR', {
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </ListSubheader>
+          {messages.map((message) => (
+            <ListItem key={`item-${message.timestamp}`}>
+              <ChatRow message={message} />
+            </ListItem>
+          ))}
+        </ul>
+      </li>
+    );
+  });
+}

--- a/web-apps/client/src/components/ChatRow.js
+++ b/web-apps/client/src/components/ChatRow.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import ChatBox from './ChatBox';
+
+const currentUser = 1;
+
+export default function ChatRow({message: {id, timestamp, message}}) {
+  const isMyChat = currentUser === id;
+  return (
+    <Grid
+      container
+      direction='row'
+      justify={isMyChat ? 'flex-end' : 'flex-start'}
+      alignItems='center'
+    >
+      <Grid item>
+        <ChatBox message={message} timestamp={timestamp} isMyChat={isMyChat} />
+      </Grid>
+    </Grid>
+  );
+}

--- a/web-apps/client/src/index.css
+++ b/web-apps/client/src/index.css
@@ -1,0 +1,22 @@
+html {
+  box-sizing: border-box;
+}
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+}

--- a/web-apps/client/src/index.js
+++ b/web-apps/client/src/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {createStore, applyMiddleware} from 'redux';
+import {Provider} from 'react-redux';
+import {ThemeProvider as MuiThemeProvider} from '@material-ui/core/styles';
+import {composeWithDevTools} from 'redux-devtools-extension';
+import {createLogger} from 'redux-logger';
+import ReduxThunk from 'redux-thunk';
+
+import './index.css';
+import App from './App';
+import muiTheme from './theme/muiTheme';
+import * as serviceWorker from './serviceWorker';
+import rootReducer from './modules';
+
+const logger = createLogger();
+const store = createStore(
+  rootReducer,
+  composeWithDevTools(applyMiddleware(logger, ReduxThunk)),
+);
+
+ReactDOM.render(
+  <Provider store={store}>
+    <MuiThemeProvider theme={muiTheme}>
+      <App />
+    </MuiThemeProvider>
+  </Provider>,
+  document.getElementById('root'),
+);
+
+serviceWorker.unregister();

--- a/web-apps/client/src/theme/muiTheme.js
+++ b/web-apps/client/src/theme/muiTheme.js
@@ -1,0 +1,23 @@
+import {createMuiTheme} from '@material-ui/core/styles';
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#0091ea',
+    },
+    secondary: {
+      main: '#78909c',
+    },
+  },
+  overrides: {
+    MuiInput: {
+      root: {
+        fontSize: '1rem',
+        fontWeight: 'bold',
+        padding: '0.5rem 0',
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## 요약

안녕하세요. 이번주는 React를 사용하여 채팅 화면을 구현하였습니다. 
현재는 서버쪽의 Websocket을 연결하지 않고, 가짜 데이터를 생성하여 사용하고 있습니다. 
요청을 모방하기 위해 Promise로 제공되는 mock 데이터를 사용하고 있고, 
무한스크롤, 채팅, 데이터 가공, 역방향 스크롤을 구현하였습니다. 

## 고민들
### 채팅 방향

저희는 채팅 화면을 구현함에 있어서 위에서 아래로 시간순으로 내려가는 방법이 아닌, 
아래에서 위로 시간순으로 올라가는 방법을 구현하고 있습니다. 

이는 보통의 채팅화면, 혹은 메신저에서 사용하는 방식으로 예상됩니다. 

이를 위해서, 저희는 시간순(뒤로갈수록 최신)으로 받은 데이터를 1차로 reverse하여 가공하고, 2차로 각각의 기준시(00시00분00초)로 객체화 합니다. (객체들의 배열)
여기서, 2차 기준시로 객체화 하는 이유는 각각의 시간들에 대해서 해당하는 날짜를 제공하기 위함입니다. 

처음에는, 기준시간별로 들어오는 (해당 날짜에) 메세지들을 시간순으로 저장하려 했으나, 
지역에 따라 시간이 다르므로, 특정 날짜를 한정시키는 방법이 아닌 timestamp만을 남기는 방법을 택하였습니다. 

### raw 한 메세지 데이터

```js
[
  {
    id: getRandomInt(0, 2),
    message:
      'Proactively implement interoperable products through cross-media schemas. Completely network goal-oriented benefits without unique ideas. ',
    timestamp: baseDate.setHours(baseDate.getHours() - 1),
  },
  //  ...
];
```

### 가공된 데이터

```js
[
  {
    baseDate: chatTime.setHours(0, 0, 0, 0),
    messages: [
      {
        id: getRandomInt(0, 2),
        message: 'Proactively implement interoperable. ',
        timestamp: baseDate.setHours(baseDate.getHours() - 1),
      },
      // ....
    ],
  },
  // ...
];
```

### 기술적인 어려움

아래로는 새로운 채팅이 추가되어야 하고, 위로는 받아오지 않은 과거의 채팅 내용이 추가되어야 합니다. 
이 과정에서 위로 들어오는 채팅 내용을 추가하기 위한 고민이 큽니다. 

저희는 위로 들어오는 과거의 채팅 내용 추가를 무한 스크롤의 형태로 구현하고자 합니다.

이 과정에, 가장 위의 엘리먼트에 Intersection observer를 등록하고, 해당 부분이 viewport에 노출되면 새로운 채팅을 fetch하는 방식입니다. 

fetch가 되어 위에 데이터가 추가되면, 기존의 스크롤 위치(최상단)에서 보고 있던 엘리먼트의 위치(추가된 데이터로 인해 밀린만큼의 스크롤 위치)로 이동해야 합니다. 

현재 구현된 코드는 최 상단 엘리먼트(Intersection observer가 지켜보는)에 닿으면, 한번의 fetch가 아닌 여러번의 fetch가 보내지는 현상이 나타나고 있습니다. (의도치 않은 결과 입니다)

이러한 현상을 최대한 방지하기 위해 클로저를 이용하여 useEffect내부에 `ignore` 를 만들기도 하였고, 별도의 추가적인 장치를 두었으나 계속해서 여러번 요청이 들어가게 되었습니다. 

이에 대한 예상으로는, 스크롤을 옮기는 과정이 있더라도, 그 전에 계속해서 최 상단에 머물고 있으므로 
새로운 데이터를 가져오고 -> 스크롤을 이동하는 과정 사이에서 최 상단에 짧은 시간 머무는 이유로 반복해서 요청이 보내지는 듯 합니다. 

안타깝게도 이 문제를 해결하지 못하였습니다.

### 의문점들

**채팅 프런트 엔드**

전반적으로 채팅의 구현과 역방향 스크롤의 구현 방법에 대해 의문을 갖고 있습니다. 
이러한 방법이 흔히 쓰이는 UX이고, 많은 서비스에서 제공하고 있는 만큼 그에 따른 적절한 구현 방법도 어느정도 확립외었을 것 같은데, 그 방법을 찾기 어렵습니다. 

**채팅 서버**

1:1 텍스트 기반의 채팅을 위한 서버를 구성하기 위한 고민을 하고있습니다. 
웹 뿐만아니라 모바일에서 대응이 되고, 그 대화의 내용을 기록하기 위해 websocket을 열어둔 서버를 중간에 두어 사용자간의 채팅을 하도록 합니다. 

webRTC와 같은 p2p 통신도 고려하였으나, 이 부분은 중간에 서버를 두는 구조가 아닌 사용자간의 통신 방식 이기에  대화 내용을 보관하기 어려울것 같아 배제하였습니다. 

또한 이러한 대화내용을 저장하는 저장소도 고민을 하고 있습니다. 
AWS S3와 같은 object storage에 log형태로 데이터를 쌓아두는 방식을 고민하고 있으며, 현업에서는 어느정도의 데이터를 유저의 디바이스에 저장하고, 어느 기간동안 정보를 서버에 저장하는지도 의문입니다.