### PR TITLE
[고경표]w5_리뷰요청_지도검색 컴포넌트

### DIFF
--- a/components/kakao-map/index.js
+++ b/components/kakao-map/index.js
@@ -1,0 +1,130 @@
+import React, { useEffect, useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { CircularProgress } from '@material-ui/core';
+import loadAPIScript from './load-api-script';
+import TYPE from './type';
+
+const KakaoMap = ({
+  appKey,
+  width,
+  height,
+  latitude,
+  longitude,
+  keyword,
+  callback
+}) => {
+  const [scriptLoading, setScriptLoading] = useState(false);
+  const [functions, setFunction] = useState(null);
+  const [timer, setTimer] = useState(null);
+  const kakaoMapArea = useRef(null);
+  const SEARCHDELAY = 500;
+  const actions = (containerRef) => () => {
+    // @ts-ignore
+    const { kakao } = window;
+    kakao.maps.load(() => {
+      setScriptLoading(true);
+      let marker;
+      let getAddressTimer;
+      const geocoder = new kakao.maps.services.Geocoder();
+      const container = containerRef.current;
+      const position = new kakao.maps.LatLng(33.450701, 126.570667);
+      const map = new kakao.maps.Map(container, { center: position, level: 3 });
+      map.setDraggable(true);
+
+      kakao.maps.event.addListener(map, 'center_changed', () => {
+        const center = map.getCenter();
+        const lat = center.getLat();
+        const lng = center.getLng();
+        if (marker) {
+          marker.setMap(null);
+        }
+        marker = new kakao.maps.Marker({ position: center });
+        marker.setMap(map);
+        if (getAddressTimer) {
+          clearTimeout(getAddressTimer);
+        }
+        const getAddressByMapMove = () => {
+          geocoder.coord2RegionCode(lng, lat, (result, status) => {
+            if (status !== kakao.maps.services.Status.OK) {
+              return;
+            }
+            if (callback) {
+              callback(TYPE.COORDINATE, {
+                lat,
+                lng,
+                name: result[0].address_name,
+                depth3: result[0].region_3depth_name,
+              });
+            }
+          });
+        }
+        getAddressTimer = setTimeout(getAddressByMapMove, SEARCHDELAY);
+      });
+
+      const findCoordsByAddress = (address) => {
+        geocoder.addressSearch(address, (result) => {
+          callback(TYPE.ADDRESS, result);
+        });
+      };
+      const findAddressByCoords = (lat, lng) => {
+        geocoder.coord2RegionCode(lng, lat, (result, status) => {
+          if (status !== kakao.maps.services.Status.OK) {
+            return;
+          }
+          map.setCenter(new kakao.maps.LatLng(lat, lng));
+        });
+      }
+      setFunction({
+        findCoordsByAddress,
+        findAddressByCoords
+      })
+    });
+  }
+
+  useEffect(loadAPIScript(appKey, actions(kakaoMapArea)), []);
+
+  const processQuarterlyLocation = () => {
+    if (!functions) {
+      return;
+    }
+    if (timer) {
+      clearTimeout(timer);
+      setTimer(null);
+    }
+    const newTimer = setTimeout(() => {
+      if (keyword.length) {
+        functions.findCoordsByAddress(keyword);
+      } else if (latitude && longitude) {
+        functions.findAddressByCoords(latitude, longitude);
+      }
+    }, SEARCHDELAY);
+    setTimer(newTimer);
+  };
+  useEffect(processQuarterlyLocation, [keyword, latitude, longitude]);
+
+  if (!scriptLoading) {
+    return <><CircularProgress /></>;
+  }
+
+  return (
+    <>
+      <div ref={kakaoMapArea} style={({ width, height })}>&nbsp;</div>
+    </>
+  );
+};
+
+KakaoMap.propTypes = {
+  appKey: PropTypes.string.isRequired,
+  width: PropTypes.string.isRequired,
+  height: PropTypes.string.isRequired,
+  keyword: PropTypes.string.isRequired,
+  latitude: PropTypes.number.isRequired,
+  longitude: PropTypes.number.isRequired,
+  callback: PropTypes.func,
+};
+
+KakaoMap.defaultProps = {
+  callback: undefined,
+};
+
+export default KakaoMap;

--- a/components/kakao-map/load-api-script.js
+++ b/components/kakao-map/load-api-script.js
@@ -1,0 +1,12 @@
+export default (appKey, callback) => () => {
+  const KAKAOAPIURL = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services,drawing`;
+  const script = document.createElement('script');
+  script.src = KAKAOAPIURL;
+  script.async = true;
+  const element = document.head.appendChild(script);
+  script.addEventListener('load', callback);
+  return () => {
+    script.removeEventListener('load', callback);
+    document.head.removeChild(element);
+  };
+};

--- a/components/kakao-map/type.js
+++ b/components/kakao-map/type.js
@@ -1,0 +1,4 @@
+export default {
+  ADDRESS: 'ADDRESS',
+  COORDINATE: 'COORDINATE',
+};

--- a/pages/area.js
+++ b/pages/area.js
@@ -1,0 +1,104 @@
+/* eslint-disable camelcase */
+import React, { useState, useRef } from 'react';
+import dotenv from 'dotenv';
+import { Grid, GridList, GridListTile, InputBase, Button } from '@material-ui/core';
+import ActionBar from '../components/action-bar';
+import ToolBar from '../components/action-bar/types/activity-layor';
+import KakakoMap from '../components/kakao-map';
+import MAPTYPE from '../components/kakao-map/type';
+
+dotenv.config();
+
+const AreaPage = () => {
+  const TITLE = '내 동네 찾기';
+  const addressRef = useRef(null);
+  const [mapInfo, setMapInfo] = useState({ latitude: 0, longitude: 0, keyword: '' });
+  const [list, setList] = useState([]);
+  const [coords, setCoords] = useState({ depth3: '전체', lat: 0, lng: 0 });
+  const setMap = ({ latitude = 0, longitude = 0, keyword = '' }) =>
+    ({ latitude, longitude, keyword });
+  const setCurrentCoordsEvent = (event) => {
+    event.preventDefault();
+    navigator.geolocation.getCurrentPosition((point) => {
+      setMapInfo(setMap({
+        latitude: point.coords.latitude,
+        longitude: point.coords.longitude
+      }));
+    });
+  };
+
+  const callback = (type, result) => {
+    if (type === MAPTYPE.COORDINATE) {
+      setList([]);
+      setCoords(result);
+      if (!addressRef.current) {
+        return;
+      }
+      addressRef.current.value = result.name;
+    } else if (type === MAPTYPE.ADDRESS) {
+      setList([...result]);
+    }
+  };
+
+  const changeArea = (lat, lng) => () => {
+    setMapInfo(setMap({
+      latitude: +lat,
+      longitude: +lng,
+    }));
+  };
+
+  const area = list.map(({ address: { address_name, x, y } }) => (
+    <GridListTile key={address_name} style={({ borderBottom: '1px solid black', padding: '1rem' })} onClick={changeArea(y, x)}>
+      <>{address_name}</>
+    </GridListTile>
+  ));
+
+  const onChangeEvent = (event) => {
+    event.preventDefault();
+    const { target: { value } } = event;
+    setMapInfo(setMap({ keyword: value }));
+  };
+
+  return (
+    <>
+      <ActionBar
+        contents={
+          <ToolBar link={`/?area=${coords.depth3},${coords.lat},${coords.lng}`} title={TITLE} />
+        }
+      />
+      <Grid
+        container
+        style={({ padding: '2rem' })}
+        direction='column'
+        spacing={0}
+      >
+        <Grid item>
+          <InputBase fullWidth placeholder="동명(읍,면)으로 검색 (ex. 서초동)" inputRef={addressRef} onChange={onChangeEvent} />
+        </Grid>
+        <Grid item>
+          <Button fullWidth variant="contained" style={({ backgroundColor: '#f4690b', color: 'white' })} onClick={setCurrentCoordsEvent}>
+            현재위치로 찾기
+          </Button>
+        </Grid>
+        <Grid item>
+          <KakakoMap
+            appKey=''
+            width='100%'
+            height='50vh'
+            latitude={mapInfo.latitude}
+            longitude={mapInfo.longitude}
+            keyword={mapInfo.keyword}
+            callback={callback}
+          />
+        </Grid>
+        <Grid item>
+          <GridList cellHeight='auto' cols={1}>
+            {area}
+          </GridList>
+        </Grid>
+      </Grid>
+    </>
+  )
+};
+
+export default AreaPage;


### PR DESCRIPTION
[구현요약]
 - 저희가 당근마켓 클론을 목적으로 하고 있어, 현재 위치정보를 받아와서 지역을 설정하거나 지역을 검색하여 해당 동네를 출력하도록 하고 있습니다.
 - 여기서 저희는 검색 시 동네 이름만 보여주는 것이 아닌 지도를 통해 사용자가 설정할 수 있게 하려합니다.
 - 저희가 지도를 구현하기 어렵기 때문에 외부 API를 사용하여 구현하고 있습니다.
 - 외부 API : 카카오 지도 웹 API
 - 카카오 지도는 react 라이브러리를 공식으로 제공하는 것이 없는 것 같아서, useEffect를 이용하여 초기 스크립트를 불러와서 주소를 검색하여 위치지를 지정하거나, 지도를 조작하여 위치지를 지정하여 좌표값 혹은 주소 리스트결과를 callback함수로 부모 element로 전달합니다.
 - 동작화면
 - ![2](https://user-images.githubusercontent.com/38881005/70291935-08919480-1820-11ea-8095-a88b3e66eea9.JPG)

 - ![1](https://user-images.githubusercontent.com/38881005/70291937-092a2b00-1820-11ea-8bab-0898eb93a51b.JPG)

[변경할 예정인 것]
 - 각각의 컴포넌트에 inline으로 style 지정되어있는 것을 material ui에서 제공하는 makeStyles 등을 이용하여 분리할 예정입니다.
 - 

[구현하면서 질문사항]
 -  각각의 component들을 hook으로 구현하다보니 함수 내부가 길어져서 이를 분리하고자합니다.
그런데 분리하다보면 각각의 변수들이 서로 연관되어 있어 이를 인자로 다 넘기고 최대한 함수형에 같게 구현하는 것이 좋은지 의견을 듣고 싶습니다.
예: )
 ```javascript
      const findCoordsByAddress = (address) => {
        geocoder.addressSearch(address, (result) => {
          callback(TYPE.ADDRESS, result);
        });
      };
      const findAddressByCoords = (lat, lng) => {
        geocoder.coord2RegionCode(lng, lat, (result, status) => {
          if (status !== kakao.maps.services.Status.OK) {
            return;
          }
          map.setCenter(new kakao.maps.LatLng(lat, lng));
        });
      }
```
위의 코드에서 geocorder 객체를 사용하는데, 이를 함수 외부로 분리하게 되면
`const findAddressByCoords = (lat, lng) => {}` 를
 `const findAddressByCoords = (geocorder, lat, lng) => {}` 또는 
`const findAddressByCoords = (geocorder) => (lat, lng) => {}` 등으로 분리하고, 해당 함수를 호출하는 곳에서
`const addressByCoordsWithGeocorder = findAddressByCoords(geocorder);` 와 같이 currying사용