### PR TITLE
[여재환]w5,6_리뷰요청_Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+node_modules
+.env
+
+

--- a/apis/auth/routes/controller/loginControl.js
+++ b/apis/auth/routes/controller/loginControl.js
@@ -1,0 +1,44 @@
+import jwt from "jsonwebtoken";
+import uri from "../../assets/uris";
+
+const getUserInfoByJWT = (req, res, next) => {
+  const { info } = res.locals;
+  const { id, name, email, latitude, longitude } = info;
+  if (info === "invalid token") {
+    res.redirect("/logout");
+  } else if (id && name.length && email.length && latitude && longitude) {
+    res.json(info);
+  } else {
+    next({ status: 500, message: "internal error" });
+  }
+};
+
+const logOutProcess = (req, res) => {
+  res.clearCookie("jwt");
+  res.end();
+};
+
+const login = async (req, res) => {
+  const { id, name, email, authority, latitude, longitude } = res.locals;
+  if (id) {
+    const token = jwt.sign(
+      {
+        id,
+        name,
+        email,
+        authority,
+        latitude,
+        longitude
+      },
+      process.env.JWT_PRIVATE_KEY
+    );
+    res.cookie("jwt", token, { path: "/", httpOnly: true });
+    res.redirect(uri.clientMainPage);
+  } else {
+    const token = jwt.sign({ name, email }, process.env.JWT_PRIVATE_KEY);
+    res.cookie("jwt", token, { path: "/enrollLocation", httpOnly: true });
+    res.redirect(uri.enrollLocationPage);
+  }
+};
+
+export { getUserInfoByJWT, logOutProcess, login };

--- a/apis/auth/routes/controller/naverOAuth.js
+++ b/apis/auth/routes/controller/naverOAuth.js
@@ -1,0 +1,16 @@
+import uri from "../../assets/uris";
+
+const redirectToNaverLoginForm = async (req, res) => {
+  const { NAVER_CLIENT_ID } = process.env;
+  const state = "RAMDOM_STATE";
+  const redirectURI = encodeURI(process.env.Naver_Callback);
+  const apiUrl = `${uri.naverAuthRequest}?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${redirectURI}&state=${state}`;
+  res.redirect(apiUrl);
+};
+
+const sendUserInfo = (req, res) => {
+  const { data } = res.locals;
+  res.json(data);
+};
+
+export { redirectToNaverLoginForm, sendUserInfo };

--- a/apis/auth/routes/index.js
+++ b/apis/auth/routes/index.js
@@ -1,0 +1,18 @@
+import express from "express";
+
+import jwtValidator from "./middlewares/jwtValidator";
+import {
+  getUserInfoByJWT,
+  logOutProcess,
+  login
+} from "./controller/loginControl";
+import { addUser } from "./middlewares/userManagement";
+
+const router = express.Router();
+
+router.get("/", (req, res) => res.send("Welcome to 폴 auth server"));
+router.get("/myInfo", jwtValidator, getUserInfoByJWT);
+router.post("/addUser", jwtValidator, addUser, login);
+router.get("/logout", logOutProcess);
+
+module.exports = router;

--- a/apis/auth/routes/middlewares/naverOAuth.js
+++ b/apis/auth/routes/middlewares/naverOAuth.js
@@ -1,0 +1,74 @@
+import axios from "axios";
+import uri from "../../assets/uris";
+
+const getAccessToken = async (req, res, next) => {
+  const { NAVER_CLIENT_ID, NAVER_CLIENT_SECRET } = process.env;
+  const redirectURI = encodeURI(process.env.Naver_Callback);
+  const { code, state } = req.query;
+  const apiUrl = `${uri.naverTokenControl}?grant_type=authorization_code&client_id=${NAVER_CLIENT_ID}&client_secret=${NAVER_CLIENT_SECRET}&redirect_uri=${redirectURI}&code=${code}&state=${state}`;
+
+  const options = {
+    method: "get",
+    url: apiUrl,
+    headers: {
+      "X-Naver-Client-Id": NAVER_CLIENT_ID,
+      "X-Naver-Client-Secret": NAVER_CLIENT_SECRET
+    }
+  };
+  try {
+    const { status, data } = await axios(options);
+    if (status === 200) {
+      const token = data.access_token;
+      res.locals.access_token = token;
+      next();
+    }
+  } catch (e) {
+    res.redirect(uri.client500ErrorPage);
+  }
+};
+
+const fetchUserInfo = async (req, res, next) => {
+  const token = res.locals.access_token;
+  try {
+    const { status, data } = await axios.get(uri.memberInfoAPI, {
+      data: { token }
+    });
+    if (status === 200) {
+      const { name, email } = data.response;
+      res.locals = { name, email };
+      next();
+    } else {
+      res.redirect(uri.client500ErrorPage);
+    }
+  } catch (e) {
+    res.redirect(uri.client500ErrorPage);
+  }
+};
+
+const getUserInfoFromResourceServer = async (req, res, next) => {
+  const { token } = req.body;
+  const options = {
+    method: "get",
+    url: uri.naverMemberProfileAccess,
+    headers: { Authorization: `Bearer ${token}` }
+  };
+
+  try {
+    const { status, data } = await axios(options);
+    if (status === 200) {
+      res.locals = { data };
+      next();
+    } else {
+      next({
+        status: 500,
+        message: "프로필 조회 실패"
+      });
+    }
+  } catch (err) {
+    next({
+      status: 500,
+      message: "err.message"
+    });
+  }
+};
+export { getAccessToken, fetchUserInfo, getUserInfoFromResourceServer };

--- a/apis/auth/routes/middlewares/userManagement.js
+++ b/apis/auth/routes/middlewares/userManagement.js
@@ -1,0 +1,51 @@
+import db from "../../models";
+import uri from "../../assets/uris";
+
+const addUser = async (req, res, next) => {
+  const { User } = db;
+  const { email, name } = res.locals;
+  const { latitude, longitude } = req.body;
+  console.log(name, email, latitude, longitude);
+  try {
+    const newUser = await User.create({
+      name,
+      email,
+      latitude,
+      longitude,
+      authority: "손님"
+    });
+    res.locals = { newUser };
+    next();
+  } catch (e) {
+    next({ status: 500, message: e.message });
+  }
+};
+
+const checkExistMember = async (req, res, next) => {
+  const { name, email } = res.locals;
+  const { User } = db;
+  try {
+    const member = await User.findOne({
+      where: { email }
+    });
+    if (member !== null) {
+      const { id, authority, latitude, longitude } = member.dataValues;
+      res.locals = {
+        id,
+        name,
+        email,
+        authority,
+        latitude,
+        longitude
+      };
+      next();
+    } else {
+      res.locals = { name, email };
+      next();
+    }
+  } catch (e) {
+    res.redirect(uri.client500ErrorPage);
+  }
+};
+
+export { addUser, checkExistMember };

--- a/apis/auth/routes/naver.js
+++ b/apis/auth/routes/naver.js
@@ -1,0 +1,24 @@
+import express from "express";
+import {
+  redirectToNaverLoginForm,
+  sendUserInfo
+} from "./controller/naverOAuth";
+import {
+  getAccessToken,
+  fetchUserInfo,
+  getUserInfoFromResourceServer
+} from "./middlewares/naverOAuth";
+import { checkExistMember } from "./middlewares/userManagement";
+import { login } from "./controller/loginControl";
+
+const router = express.Router();
+
+router.get("/", (req, res) => {
+  res.send("폴은 Naver OAuth 사용중");
+});
+
+router.get("/login", redirectToNaverLoginForm);
+router.get("/callback", getAccessToken, fetchUserInfo, checkExistMember, login);
+router.get("/member", getUserInfoFromResourceServer, sendUserInfo);
+
+module.exports = router;

--- a/apis/auth/tests/index.test.js
+++ b/apis/auth/tests/index.test.js
@@ -1,0 +1,102 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import dotenv from "dotenv";
+import app from "../app";
+import uri from "../assets/uris";
+
+dotenv.config();
+
+const tester = {
+  id: 2,
+  name: "tester",
+  email: "test@jest.com",
+  authority: "손님",
+  latitude: 123.1234,
+  longitude: 76.1234,
+  reputation: 10,
+  numberOfRater: 3
+};
+
+it("get current user info test", () =>
+  new Promise(done => {
+    const key = process.env.JWT_PRIVATE_KEY;
+    const token = jwt.sign(tester, key);
+
+    request(app)
+      .get("/myInfo")
+      .set("Cookie", [`jwt=${token}`])
+      .then(res => done(res));
+  }).then(res => {
+    expect(res.status).toBe(200);
+    expect(res.text).toBe(JSON.stringify(tester));
+  }));
+it("log out test", () =>
+  new Promise(done => {
+    const key = process.env.JWT_PRIVATE_KEY;
+    const token = jwt.sign(tester, key);
+
+    request(app)
+      .get("/logout")
+      .set("Cookie", [`jwt=${token}`])
+      .then(res => done(res));
+  }).then(res => {
+    expect(res.status).toBe(200);
+    expect(res.headers["set-cookie"][0]).toBe(
+      "jwt=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    );
+  }));
+
+it("use invalid jwt token test", () =>
+  new Promise(done => {
+    const key = "random Wrong key";
+    const token = jwt.sign(tester, key);
+
+    request(app)
+      .get("/myInfo")
+      .set("Cookie", [`jwt=${token}`])
+      .then(res => done(res));
+  }).then(res => {
+    expect(res.status).toBe(400);
+  }));
+
+it("add User test", () =>
+  new Promise(done => {
+    const newUser = {
+      name: "tester",
+      email: `${new Date().getMilliseconds() +
+        new Date().getMilliseconds()}tester@jest.com`
+    };
+    const key = process.env.JWT_PRIVATE_KEY;
+    const token = jwt.sign(newUser, key);
+
+    request(app)
+      .post("/addUser")
+      .send({ latitude: 123.456, longitude: 76.54 })
+      .set("Cookie", [`jwt=${token}`])
+      .then(res => done(res));
+  }).then(res => {
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(uri.clientMainPage);
+  }));
+
+it("add user fail test", () =>
+  new Promise(done => {
+    const newUser = {
+      name: "tester",
+      email: `${new Date().getMilliseconds() +
+        new Date().getMilliseconds()}tester@jest.com`
+    };
+    const key = "invalid wrong key";
+    const token = jwt.sign(newUser, key);
+
+    request(app)
+      .post("/addUser")
+      .send({ latitude: 123.456, longitude: 76.54 })
+      .set("Cookie", [`jwt=${token}`])
+      .then(res => done(res));
+  }).then(res => {
+    expect(res.status).toBe(400);
+    expect(res.headers["set-cookie"][0]).toBe(
+      "jwt=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    );
+  }));


### PR DESCRIPTION
네이버 OAuth를 구현하는데 있어 질문이 있습니다.
현재 /naver/login으로 들어오면 네이버 로그인 화면으로 redirect 해주고
네이버 Authorization server로 부터 /naver/callback으로 토큰을 받아
다시 회원 프로필을 요청하고 있습니다.

원하는 방식은 프로필 요청에 대한 응답으로 redirect가 일어나지 않고 json으로 받고 싶은데 혹시 좋은 방법이 있는지 궁금합니다.

또 현재 인증이 jwt 기반인데 httpOnly 설정을 하다 보니 인증된 정보를 조회하려면 서버를 다시 거쳐야하는 상황입니다. 혹시 더 좋은 방법이 있다면 알고싶습니다.

인증과정의 전반적인 프로세스도 점검해주시면 감사하겠습니다.

인증서버에서 테스트 코드를 supertest를 이용하여 구현하였는데 redirect 결과가 나오는 코드에서 jest가 Jest did not exit one second after the test run has completed. 오류와 함께 끝나지 않는 이슈가 있습니다. 해당 부분은 forceExit 옵션을 통해 해결하였는데 다른 해결법이 있으면 알고 싶습니다.

코드 첨부는 하지 않았지만 프론트 엔드에서 저희팀은 rem 을 사용하고 있는데 반응형을 고려했을때 html의 크기를 vmin등을 이용하여 font-size를 동적으로 설정하는것과 디폴트설정만을 사용하는 것에 대한 고민이 있습니다.

감사합니다!